### PR TITLE
added support for 2.8.0-beta-1 recipes and a converter script

### DIFF
--- a/recex-converter.rb
+++ b/recex-converter.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-class Convert
+class RecexConverter
   attr_reader :input, :output
 
   def initialize(input, output)
@@ -61,8 +61,8 @@ if ARGV.length != 2
   abort "Usage: #{$0} in.json out.json"
 end
 
-convertor = Convert.new(ARGV[0], ARGV[1])
-convertor.write
+converter = RecexConverter.new(ARGV[0], ARGV[1])
+converter.write
 
 
 

--- a/recex-converter.rb
+++ b/recex-converter.rb
@@ -1,0 +1,68 @@
+require 'json'
+
+class Convert
+  attr_reader :input, :output
+
+  def initialize(input, output)
+    @input = input
+    @output = output
+  end
+
+  def write
+    hash = Hash.new
+    hash["machines"] = machines
+    hash["smelting"] = smelting
+
+    File.write(output, hash.to_json)
+  end
+
+  def machines
+    parsed["sources"].each do |source|
+      if source.key?("machines")
+        return fix_dur(source["machines"])
+      end
+    end
+
+    raise StandardError, "Key `machines` not found"
+  end
+
+  def fix_dur(machines)
+    [].tap do |array|
+      machines.each do |machine|
+        hash = Hash.new
+        hash["n"] = machine["n"]
+        hash["recs"] = machine["recs"].map do |recipe|
+          new_recipe = recipe.clone
+          new_recipe["dur"] = recipe["dur"] * -1 if recipe["dur"] < 0
+          new_recipe
+        end
+
+        array << hash
+      end
+    end
+  end
+
+  def smelting
+    parsed["sources"].each do |source|
+      if source["type"] == "smelting"
+        return source["recipes"]
+      end
+    end
+
+    raise StandardError, "smelting type not found"
+  end
+  
+  private def parsed
+    @parsed ||= JSON.parse(File.read(input))
+  end
+end
+
+if ARGV.length != 2
+  abort "Usage: #{$0} in.json out.json"
+end
+
+convertor = Convert.new(ARGV[0], ARGV[1])
+convertor.write
+
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,10 @@ fn main() -> Result<(), std::io::Error> {
             "n987".to_string(),
             serde_json::from_str::<RecipeDatabase>(include_str!("recipes/recipes-n987.json"))?,
         ),
+        (
+            "2.8.0-beta-1".to_string(),
+            serde_json::from_str::<RecipeDatabase>(include_str!("recipes/recipes-2.8.0-beta-1.json"))?,
+        ),
     ]));
 
     for stream in listener.incoming() {


### PR DESCRIPTION
Updated the code to support recipes for 2.8.0-beta-1.
Also added a recex-converter.rb script to generate a valid json file from the RecEx-Records generated file.

Usage for example:
`ruby recex-converter.rb RecEx-Records/2025-08-04_14-35-52.json /tmp/out.json`
